### PR TITLE
Add GetVariableNames method to EquationCompiler

### DIFF
--- a/Tests/OperatorTests.cs
+++ b/Tests/OperatorTests.cs
@@ -235,5 +235,21 @@ namespace dotMath.Tests
 			var compiler = new EquationCompiler("4+");
 			Assert.Throws<InvalidEquationException>(() => compiler.Calculate());
 		}
-	}
+
+        [Test]
+        public void GetVariableNames()
+        {
+            var compiler = new EquationCompiler("a+b+c");
+
+            CollectionAssert.AreEquivalent(new string[] { "a", "b", "c" }, compiler.GetVariableNames());
+        }
+
+        [Test]
+        public void GetVariableNames_CollectionIsReadOnly()
+        {
+            var compiler = new EquationCompiler("a+b+c");
+
+            Assert.IsTrue(compiler.GetVariableNames().IsReadOnly);
+        }
+    }
 }

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -121,9 +121,6 @@
       <Name>dotMath</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PreBuildEvent />

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -121,6 +121,9 @@
       <Name>dotMath</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PreBuildEvent />

--- a/dotMath/EquationCompiler.cs
+++ b/dotMath/EquationCompiler.cs
@@ -33,6 +33,10 @@ namespace dotMath
 			InitFunctions();
 		}
 
+        /// <summary>
+        /// Gets the string variable names parsed by compiling the function.
+        /// </summary>
+        /// <returns>Read-only collection of variable names</returns>
         public ICollection<string> GetVariableNames()
         {
             if (_function == null)

--- a/dotMath/EquationCompiler.cs
+++ b/dotMath/EquationCompiler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using dotMath.Core;
 using dotMath.Exceptions;
 
@@ -32,12 +33,20 @@ namespace dotMath
 			InitFunctions();
 		}
 
-		/// <summary>
-		/// Sets the object mapped to the string variable name to the double value passed.
-		/// </summary>
-		/// <param name="name">Variable Name</param>
-		/// <param name="value">New Value for variable</param>
-		public void SetVariable(string name, double value)
+        public ICollection<string> GetVariableNames()
+        {
+            if (_function == null)
+                Compile();
+
+            return _variables.Keys;
+        }
+
+        /// <summary>
+        /// Sets the object mapped to the string variable name to the double value passed.
+        /// </summary>
+        /// <param name="name">Variable Name</param>
+        /// <param name="value">New Value for variable</param>
+        public void SetVariable(string name, double value)
 		{
 			CVariable variable = GetVariableByName(name);
 			variable.SetValue(value);


### PR DESCRIPTION
I have a use case in which I need to list the variable names that were parsed in the equation. For now I'm resorting to reflection to extract them (for which I feel shame) so I'd like this supported by the library. Only added functionality so should be a minor update according to semantic versioning.
