### PR TITLE
Add GetVariableNames method to EquationCompiler (#2)

### DIFF
--- a/Tests/FunctionTests.cs
+++ b/Tests/FunctionTests.cs
@@ -227,7 +227,19 @@ namespace dotMath.Tests
 			Assert.AreEqual(Math.Sin(a) + Math.Cos(b) - Math.Tan(c), compiler.Calculate());
 		}
 
-		[TestCase(4, 2)]
+        [TestCase(1.5, 2.25, 3.3)]
+        [TestCase(-1.5, -2.25, -3.3)]
+        public void MultipleOfSameFunction(double a, double b, double c)
+        {
+            var compiler = new EquationCompiler("sin(a) + sin(b) - sin(c)");
+            compiler.SetVariable("a", a);
+            compiler.SetVariable("b", b);
+            compiler.SetVariable("c", c);
+
+            Assert.AreEqual(Math.Sin(a) + Math.Sin(b) - Math.Sin(c), compiler.Calculate());
+        }
+
+        [TestCase(4, 2)]
 		[TestCase(2, 4)]
 		[TestCase(4, -2)]
 		public void Min(double a, double b)

--- a/Tests/OperatorTests.cs
+++ b/Tests/OperatorTests.cs
@@ -235,5 +235,21 @@ namespace dotMath.Tests
 			var compiler = new EquationCompiler("4+");
 			Assert.Throws<InvalidEquationException>(() => compiler.Calculate());
 		}
-	}
+
+        [Test]
+        public void GetVariableNames()
+        {
+            var compiler = new EquationCompiler("a+b+c");
+
+            CollectionAssert.AreEquivalent(new string[] { "a", "b", "c" }, compiler.GetVariableNames());
+        }
+
+        [Test]
+        public void GetVariableNames_CollectionIsReadOnly()
+        {
+            var compiler = new EquationCompiler("a+b+c");
+
+            Assert.IsTrue(compiler.GetVariableNames().IsReadOnly);
+        }
+    }
 }

--- a/Tests/OperatorTests.cs
+++ b/Tests/OperatorTests.cs
@@ -218,7 +218,17 @@ namespace dotMath.Tests
 			return compiler.Calculate();
 		}
 
-		[TestCase("4!2")]
+        [TestCase("1 + 2 + 3", ExpectedResult = 1 + 2 + 3)]
+        [TestCase("1 - 2 - 3", ExpectedResult = 1 - 2 - 3)]
+        [TestCase("1 * 2 * 3", ExpectedResult = 1 * 2 * 3)]
+        [TestCase("1 / 2 / 3", ExpectedResult = 1.0 / 2.0 / 3.0)]
+        public double MultipleOfSameOperator(string equation)
+        {
+            var compiler = new EquationCompiler(equation);
+            return compiler.Calculate();
+        }
+
+        [TestCase("4!2")]
 		[TestCase("4~2")]
 		[TestCase("4$2")]
 		[TestCase("4\"2")]

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -121,9 +121,6 @@
       <Name>dotMath</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PreBuildEvent />

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -121,6 +121,9 @@
       <Name>dotMath</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PreBuildEvent />

--- a/dotMath/Core/BaseClasses.cs
+++ b/dotMath/Core/BaseClasses.cs
@@ -82,10 +82,14 @@ namespace dotMath.Core
 			_function = function;
 		}
 
-		public void SetParameters(CValue param1, CValue param2)
+		public COperator SetParameters(CValue param1, CValue param2)
 		{
-			_param1 = param1;
-			_param2 = param2;
+            var clone = new COperator(_function);
+
+            clone._param1 = param1;
+            clone._param2 = param2;
+
+            return clone;
 		}
 
 		public override double GetValue()
@@ -122,9 +126,15 @@ namespace dotMath.Core
 			_expectedArgCount = 3;
 		}
 
-		public void SetParameters(List<CValue> values)
+        private CFunction(object function, int expectedArgCount)
+        {
+            _function = function;
+            _expectedArgCount = expectedArgCount;
+        }
+
+		public CFunction SetParameters(List<CValue> values)
 		{
-			// validate argument count
+            // validate argument count
 			if (_expectedArgCount != values.Count)
 				throw new ArgumentCountException(values.Count);
 
@@ -135,7 +145,11 @@ namespace dotMath.Core
 					throw new ArgumentCountException(values.Count);
 			}
 
-			_parameters = values;
+            var clone = new CFunction(_function, _expectedArgCount);
+
+            clone._parameters = values;
+
+            return clone;
 		}
 
 		public override double GetValue()

--- a/dotMath/EquationCompiler.cs
+++ b/dotMath/EquationCompiler.cs
@@ -33,6 +33,10 @@ namespace dotMath
 			InitFunctions();
 		}
 
+        /// <summary>
+        /// Gets the string variable names parsed by compiling the function.
+        /// </summary>
+        /// <returns>Read-only collection of variable names</returns>
         public ICollection<string> GetVariableNames()
         {
             if (_function == null)

--- a/dotMath/EquationCompiler.cs
+++ b/dotMath/EquationCompiler.cs
@@ -174,8 +174,7 @@ namespace dotMath
 
 							isFunction = true;
 
-							function.SetParameters(parameters);
-							value = function;
+							value = function.SetParameters(parameters);
 						}
 						else
 							value = GetVariableByName(_currentToken.ToString());
@@ -335,8 +334,8 @@ namespace dotMath
 			if (_operators.ContainsKey(operatorToken.ToString()))
 			{
 				COperator op = _operators[operatorToken.ToString()];
-				op.SetParameters(value1, value2);
-				return op;
+
+                return op.SetParameters(value1, value2);
 			}
 
 			throw new InvalidEquationException("Invalid operator found in equation: " + operatorToken.ToString());

--- a/dotMath/EquationCompiler.cs
+++ b/dotMath/EquationCompiler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using dotMath.Core;
 using dotMath.Exceptions;
 
@@ -32,12 +33,20 @@ namespace dotMath
 			InitFunctions();
 		}
 
-		/// <summary>
-		/// Sets the object mapped to the string variable name to the double value passed.
-		/// </summary>
-		/// <param name="name">Variable Name</param>
-		/// <param name="value">New Value for variable</param>
-		public void SetVariable(string name, double value)
+        public ICollection<string> GetVariableNames()
+        {
+            if (_function == null)
+                Compile();
+
+            return _variables.Keys;
+        }
+
+        /// <summary>
+        /// Sets the object mapped to the string variable name to the double value passed.
+        /// </summary>
+        /// <param name="name">Variable Name</param>
+        /// <param name="value">New Value for variable</param>
+        public void SetVariable(string name, double value)
 		{
 			CVariable variable = GetVariableByName(name);
 			variable.SetValue(value);


### PR DESCRIPTION
I have a use case in which I need to list the variable names that were parsed in the equation. For now I'm resorting to reflection to extract them (for which I feel shame) so I'd like this supported by the library. Only added functionality so should be a minor update according to semantic versioning.

(This is the second attempt at the pull request, now including doc comments.)
