### PR TITLE
Fix Usage of Same Operator/Function Multiple Times in Equation

### DIFF
--- a/Tests/FunctionTests.cs
+++ b/Tests/FunctionTests.cs
@@ -227,7 +227,19 @@ namespace dotMath.Tests
 			Assert.AreEqual(Math.Sin(a) + Math.Cos(b) - Math.Tan(c), compiler.Calculate());
 		}
 
-		[TestCase(4, 2)]
+        [TestCase(1.5, 2.25, 3.3)]
+        [TestCase(-1.5, -2.25, -3.3)]
+        public void MultipleOfSameFunction(double a, double b, double c)
+        {
+            var compiler = new EquationCompiler("sin(a) + sin(b) - sin(c)");
+            compiler.SetVariable("a", a);
+            compiler.SetVariable("b", b);
+            compiler.SetVariable("c", c);
+
+            Assert.AreEqual(Math.Sin(a) + Math.Sin(b) - Math.Sin(c), compiler.Calculate());
+        }
+
+        [TestCase(4, 2)]
 		[TestCase(2, 4)]
 		[TestCase(4, -2)]
 		public void Min(double a, double b)

--- a/Tests/OperatorTests.cs
+++ b/Tests/OperatorTests.cs
@@ -218,7 +218,17 @@ namespace dotMath.Tests
 			return compiler.Calculate();
 		}
 
-		[TestCase("4!2")]
+        [TestCase("1 + 2 + 3", ExpectedResult = 1 + 2 + 3)]
+        [TestCase("1 - 2 - 3", ExpectedResult = 1 - 2 - 3)]
+        [TestCase("1 * 2 * 3", ExpectedResult = 1 * 2 * 3)]
+        [TestCase("1 / 2 / 3", ExpectedResult = 1.0 / 2.0 / 3.0)]
+        public double MultipleOfSameOperator(string equation)
+        {
+            var compiler = new EquationCompiler(equation);
+            return compiler.Calculate();
+        }
+
+        [TestCase("4!2")]
 		[TestCase("4~2")]
 		[TestCase("4$2")]
 		[TestCase("4\"2")]

--- a/dotMath/Core/BaseClasses.cs
+++ b/dotMath/Core/BaseClasses.cs
@@ -82,10 +82,14 @@ namespace dotMath.Core
 			_function = function;
 		}
 
-		public void SetParameters(CValue param1, CValue param2)
+		public COperator SetParameters(CValue param1, CValue param2)
 		{
-			_param1 = param1;
-			_param2 = param2;
+            var clone = new COperator(_function);
+
+            clone._param1 = param1;
+            clone._param2 = param2;
+
+            return clone;
 		}
 
 		public override double GetValue()
@@ -122,9 +126,15 @@ namespace dotMath.Core
 			_expectedArgCount = 3;
 		}
 
-		public void SetParameters(List<CValue> values)
+        private CFunction(object function, int expectedArgCount)
+        {
+            _function = function;
+            _expectedArgCount = expectedArgCount;
+        }
+
+		public CFunction SetParameters(List<CValue> values)
 		{
-			// validate argument count
+            // validate argument count
 			if (_expectedArgCount != values.Count)
 				throw new ArgumentCountException(values.Count);
 
@@ -135,7 +145,11 @@ namespace dotMath.Core
 					throw new ArgumentCountException(values.Count);
 			}
 
-			_parameters = values;
+            var clone = new CFunction(_function, _expectedArgCount);
+
+            clone._parameters = values;
+
+            return clone;
 		}
 
 		public override double GetValue()

--- a/dotMath/EquationCompiler.cs
+++ b/dotMath/EquationCompiler.cs
@@ -174,8 +174,7 @@ namespace dotMath
 
 							isFunction = true;
 
-							function.SetParameters(parameters);
-							value = function;
+							value = function.SetParameters(parameters);
 						}
 						else
 							value = GetVariableByName(_currentToken.ToString());
@@ -335,8 +334,8 @@ namespace dotMath
 			if (_operators.ContainsKey(operatorToken.ToString()))
 			{
 				COperator op = _operators[operatorToken.ToString()];
-				op.SetParameters(value1, value2);
-				return op;
+
+                return op.SetParameters(value1, value2);
 			}
 
 			throw new InvalidEquationException("Invalid operator found in equation: " + operatorToken.ToString());


### PR DESCRIPTION
It turns out that the library has a serious bug when attempting to use an operator or function multiple times in the same equation. Using the same operator immediately after a previous usage e.g. "1 + 2 + 3" will throw a StackOverflowException, as will using a function as an argument to itself e.g. "abs(abs(-3))".

The fix involves cloning CFunction and COperator objects when setting parameters, ensuring parameters aren't overwritten on the same object multiple times.

Pull request includes tests to verify the changes.
