### PR TITLE
Fix parsing of nested function with multiple parameters

### DIFF
--- a/Tests/FunctionTests.cs
+++ b/Tests/FunctionTests.cs
@@ -189,6 +189,13 @@ namespace dotMath.Tests
 			Assert.AreEqual(Math.Sin(Math.Cos(Math.Tan(a))), compiler.Calculate());
 		}
 
+        [Test]
+        public void NestedFunctionsWithMultipleParameters()
+        {
+            var compiler = new EquationCompiler("max(1,min(2,3))");
+			Assert.AreEqual(2, compiler.Calculate());
+        }
+
 		[Test]
 		public void RangeTest()
 		{
@@ -286,6 +293,13 @@ namespace dotMath.Tests
 
             compiler.SetFunction(string.Format("if({0},a,(b+c))", condition));
             Assert.AreEqual((result ? a : b + c), compiler.Calculate());
+        }
+
+        [Test]
+        public void NestedIf()
+        {
+			var compiler = new EquationCompiler("if(1, if(1, 2, 3), 4)");
+			Assert.AreEqual(2, compiler.Calculate());
         }
 
         [Test]

--- a/dotMath/EquationCompiler.cs
+++ b/dotMath/EquationCompiler.cs
@@ -188,6 +188,9 @@ namespace dotMath
 							isFunction = true;
 
 							value = function.SetParameters(parameters);
+
+							if (string.Equals(_currentToken, ")") && parameters.Count > 1)
+								NextToken();
 						}
 						else
 							value = GetVariableByName(_currentToken.ToString());


### PR DESCRIPTION
Simple expressions like these were not being parsed correctly:
```
max(1,min(2,3))
if(1, if(1, 2, 3), 4)
```
I wrote unit tests for them and fixed the problem with a simple hack. Not the prettiest, but it works now.