### PR TITLE
Added new custom function support for Func<double,double,double,double>

### DIFF
--- a/Tests/FunctionTests.cs
+++ b/Tests/FunctionTests.cs
@@ -359,5 +359,27 @@ namespace dotMath.Tests
 			var compiler = new EquationCompiler(equation);
 			Assert.Throws<ArgumentCountException>(() => compiler.Calculate());
 		}
+
+        [TestCase(1, 2, 3, 6)]
+		[TestCase(5, 10, 15, 30)]
+        public void SupportFunc4Double_Succeeds(double a, double b, double c, double d)
+        {
+			var compiler = new EquationCompiler($"sum({a},{b},{c})");
+			compiler.AddFunction("sum", (double x, double y, double z) => x + y + z);
+            Assert.AreEqual(d, compiler.Calculate());
+        }
+
+		[TestCase(1, 1.0, 2.0, 1.0)]
+		[TestCase(0, 1.0, 2.0, 2.0)]
+		public void SupportFuncBool3Double_Succeeds(double a, double b, double c, double d) 
+		{
+			var compiler = new EquationCompiler($"test({a},{b},{c})");
+			compiler.AddFunction("test", (bool x, double y, double z) => 
+			{
+				if (x) return y;
+				else return z;
+			});
+		 	Assert.AreEqual(d, compiler.Calculate());
+		}
 	}
 }

--- a/dotMath/Core/BaseClasses.cs
+++ b/dotMath/Core/BaseClasses.cs
@@ -126,6 +126,12 @@ namespace dotMath.Core
 			_expectedArgCount = 3;
 		}
 
+		public CFunction(Func<double, double, double, double> function)
+		{
+			_function = function;
+			_expectedArgCount = 3;
+		}
+
         private CFunction(object function, int expectedArgCount)
         {
             _function = function;
@@ -161,7 +167,17 @@ namespace dotMath.Core
 				case 2:
 					return (_function as Func<double, double, double>)(((CValue) _parameters[0]).GetValue(), ((CValue) _parameters[1]).GetValue());
 				case 3:
-					return (_function as Func<bool, double, double, double>)(Convert.ToBoolean(((CValue) _parameters[0]).GetValue()), ((CValue) _parameters[1]).GetValue(), ((CValue) _parameters[2]).GetValue());
+					var boolFunction = _function as Func<bool, double, double, double>;
+					if (boolFunction != null) 
+					{
+						return boolFunction(Convert.ToBoolean(((CValue) _parameters[0]).GetValue()), ((CValue) _parameters[1]).GetValue(), ((CValue) _parameters[2]).GetValue());
+					}
+					var doubleFunction = _function as Func<double, double, double, double>;
+					if (doubleFunction != null) 
+					{
+						return doubleFunction(((CValue) _parameters[0]).GetValue(), ((CValue) _parameters[1]).GetValue(), ((CValue) _parameters[2]).GetValue());
+					}
+					throw new InvalidOperationException("The Custom Function Type is not supported");
 				default:
 					throw new ArgumentCountException(_parameters.Count);
 			}

--- a/dotMath/EquationCompiler.cs
+++ b/dotMath/EquationCompiler.cs
@@ -126,6 +126,16 @@ namespace dotMath
 			_functions.Add(name, new CFunction(function));
 		}
 
+		/// <summary>
+		/// Adds a custom function with the given name.
+		/// </summary>
+		/// <param name="name">Name of function.</param>
+		/// <param name="function">Function delegate.</param>
+		public void AddFunction(string name, Func<double, double, double, double> function)
+		{
+			_functions.Add(name, new CFunction(function));
+		}
+
 		#region Operations and Compiling Functions
 
 		/// <summary>
@@ -191,7 +201,7 @@ namespace dotMath
 							if (string.Equals(_currentToken, ")") && parameters.Count > 1)
 								NextToken();
 						}
-						else
+                        else
 							value = GetVariableByName(_currentToken.ToString());
 
 						break;


### PR DESCRIPTION
Hi, I'd like to add support for a custom function that has 3 double parameters and outputs a double.  
I also noticed a bug with the Func<bool,double,double,double> if the equation uses True or False.  For example, "custom(True,1,2)", the boolean value will always be treated as false.  This could be fixed by treating True and False as keywords in the compiler's Paren() method.  Can I fix that?