### PR TITLE
Fix bug regarding cultural number formatting

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
-version: 1.5.2.{build}
+version: 1.5.3.{build}
 
 environment:
-  packageVersion: 1.5.2
+  packageVersion: 1.5.3
 
 image: Visual Studio 2019
 

--- a/dotMath/Core/BaseClasses.cs
+++ b/dotMath/Core/BaseClasses.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using dotMath.Exceptions;
 
 namespace dotMath.Core
@@ -41,7 +42,7 @@ namespace dotMath.Core
 
 		public CNumber(string value)
 		{
-			_value = Convert.ToDouble(value);
+			_value = Convert.ToDouble(value, CultureInfo.InvariantCulture);
 		}
 
 		public override double GetValue()


### PR DESCRIPTION
When a number is written as 0.5 but the CurrentCulture sets the decimal delimiter as , (for example in German), the 0.5 will be parsed as a 5 by Convert.ToDouble. InvariantCulture needs to be passed to prevent this.